### PR TITLE
Set check to true in run_command

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -32,7 +32,7 @@ if get_option('is_devel')
   app_id_suffix = '-Devel'
 
   find_program('git', required: true)
-  vcs_tag = run_command('git', 'rev-parse', '--short', 'HEAD').stdout().strip()
+  vcs_tag = run_command('git', 'rev-parse', '--short', 'HEAD', check: true).stdout().strip()
   version_suffix = '-dev.@0@'.format (vcs_tag)
 endif
 


### PR DESCRIPTION
As of meson 0.61.0, the following warning is printed when running `meson setup`:

```
Program git found: YES (/usr/bin/git)
WARNING: You should add the boolean check kwarg to the run_command call.
         It currently defaults to false,
         but it will default to true in future releases of meson.
         See also: https://github.com/mesonbuild/meson/issues/9300
```